### PR TITLE
[BarClerk-550] - [FE] Integrate User Sign-In API

### DIFF
--- a/client/components/molecules/CustomForm/index.tsx
+++ b/client/components/molecules/CustomForm/index.tsx
@@ -9,6 +9,7 @@ type Props = {
   className?: string
   placeholder: string
   isPassHidden?: boolean
+  defaultValue?:string
   setIsPassHidden?: (value: boolean) => void
 }
 
@@ -16,6 +17,7 @@ const CustomForm = ({
   label,
   className,
   isPassHidden,
+  defaultValue,
   setIsPassHidden = () => { },
   ...props
 }: Props) => {
@@ -31,8 +33,8 @@ const CustomForm = ({
         <div className="relative">
           <input
             {...field}
-            {...props}
-            value={field?.value || ""}
+            {...props} 
+            value={field?.value || defaultValue || ""}
             className={`
               px-2 pb-1
               placeholder-text-failed   

--- a/client/pages/sign-in.tsx
+++ b/client/pages/sign-in.tsx
@@ -1,28 +1,42 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
 import { Formik, Form } from "formik";
-import { setCookie } from 'cookies-next';
+import { setCookie, deleteCookie, getCookie } from 'cookies-next';
 import React, { useState } from "react";
 
+import { Cookie } from "shared/types";
 import Button from "components/atoms/Button";
 import NextHead from "components/atoms/NextHead";
+import { useAuthMethods } from "hooks/authMethods";
 import { SignInFormSchema } from "shared/validation";
 import CustomForm from "components/molecules/CustomForm";
 
 const SignIn = () => {
+  const { handleSignInSubmit } = useAuthMethods();
   const [isPassHidden, setIsPassHidden] = useState<boolean>(true);
+  const [rememberMe, setRememberMe] = useState<string>("");
+  const isRemembered: Cookie = getCookie('isRemembered') || false;
+  const rememberedEmail: Cookie = getCookie('email') || "";
 
   const formikInitialValues = {
     email: "",
     password: ""
   };
 
-  const onClickRemember = (e: any) => {
-    setCookie('isRemembered', e.target.checked);
+  const onChangeRemember = (e: { target: any }) => {
+    const { value, name } = e.target;
+    if (name === "password") return;
 
-    if (e.target.checked) {
-      setCookie('email', formikInitialValues.email);
-    }
+    setRememberMe(value);
+    if (isRemembered) return setCookie('email', value);
+  }
+
+  const onClickRemember = (e: { target: any }) => {
+    const { checked } = e.target;
+
+    setCookie('isRemembered', checked);
+    if (!checked) return deleteCookie('email');
+    setCookie('email', rememberMe)
   }
 
   return (
@@ -39,16 +53,17 @@ const SignIn = () => {
             <Formik
               initialValues={formikInitialValues}
               validationSchema={SignInFormSchema}
-              onSubmit={()=>{}}
+              onSubmit={handleSignInSubmit}
             >
               {({ isSubmitting }): any => {
                 return (
                   <Form>
-                    <div className="flex flex-col gap-4 ">
+                    <div className="flex flex-col gap-4" onChange={onChangeRemember}>
                       <CustomForm
                         label="Email address"
                         name="email"
                         type="email"
+                        defaultValue={rememberedEmail}
                         placeholder="john.doe@email.com"
                       />
                       <CustomForm
@@ -66,7 +81,7 @@ const SignIn = () => {
                         <input
                           id="remember"
                           type="checkbox"
-                          value=""
+                          defaultChecked={isRemembered}
                           onClick={onClickRemember}
                           className="h-3 w-3 rounded-sm border border-gray-300 bg-transparent"
                         />

--- a/client/shared/types/index.ts
+++ b/client/shared/types/index.ts
@@ -42,3 +42,6 @@ export type InitialState = {
 export type Store = {
   auth: InitialState;
 };
+
+// Consumes a lot of time for me, for now I added type any. Need help on this.
+export type Cookie = string | boolean | any; 

--- a/client/shared/validation/index.ts
+++ b/client/shared/validation/index.ts
@@ -17,10 +17,10 @@ export const SignUpFormSchema = Yup.object().shape({
   email: Yup.string().email().required().label('Email'),
   password: Yup.string()
     .required('Password is required')
-    .min(4, 'Password length should be at least 4 characters')
-    .max(12, 'Password cannot exceed more than 12 characters'),
+    .min(8, 'Password length should be at least 8 characters')
+    .max(15, 'Password cannot exceed more than 15 characters'),
   password_confirmation: Yup.string()
     .required('Confirm Password is required')
-    .max(12, 'Password cannot exceed more than 12 characters')
+    .max(15, 'Password cannot exceed more than 15 characters')
     .oneOf([Yup.ref('password')], 'Passwords do not match'),
 });


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203234368773394/1203256158175550/f

## Definition of Done
- [ ] Users can use their registered email and password
- [ ] Users can see errors if they input the wrong credentials

## Pre-condition
- yarn

## Expected Output
- When the user credentials are met, it should redirect to the home page
- When the user credentials are wrong, it should return an error message
- When the user clicks the remember me a box, it should remember their email address
- If the user removes the remember me a box, it should not remember their email address

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/93037350/199867858-b9ac0061-4753-4f26-9a7f-ae8e4a356ffd.png)
![image](https://user-images.githubusercontent.com/93037350/199867870-16a5fdaf-0c79-47c6-9e94-d578510b9747.png)
![image](https://user-images.githubusercontent.com/93037350/199867945-871ce5ef-acee-491f-84ce-3951f48d77e6.png)
![image](https://user-images.githubusercontent.com/93037350/199867977-d5bd7f17-36db-4bd3-b02b-6ca7e8584e15.png)
![image](https://user-images.githubusercontent.com/93037350/199868025-a9b2dc75-4be5-41cb-b611-088471e20c02.png)
