### PR TITLE
[BarClerk-551] - [FE] Implement Route Protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,43 @@
-## BARCLERK
-### API
-- https://barclerk.herokuapp.com/api
-### Client: 
-- https://barclerk.vercel.app
+## BARCLERK 
+# Description
+
+This tool/application aims to solve problems faced by legal practitioners in Western Australia particularly when it comes to matters from Legal Aid. Such problems include tracking the list of all the matters from Legal Aid, as well as billing.
+
+## 🔗 Links
+
+- Client :: https://barclerk.vercel.app
+- Server :: https://barclerk.herokuapp.com/api
+
+## Developers
+
+- [@AJ](https://github.com/abduljalilpalala) 
+- [@John](https://github.com/johnpaul-sun)
+- [@Joshua](https://github.com/jsvelte) 
+
+## Quality Assurance
+
+- [@AJ](https://github.com/abduljalilpalala) 
+- [@John](https://github.com/johnpaul-sun)
+- [@Joshua](https://github.com/jsvelte) 
+
+## License
+
+[![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/tterb/atomic-design-ui/blob/master/LICENSEs)
+[![AGPL License](https://img.shields.io/badge/license-AGPL-blue.svg)](http://www.gnu.org/licenses/agpl-3.0)
+[![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
+
+## Tech Stack
+
+**Client:** 
+- Next.js
+- Redux Toolkit
+- Redux Thunk
+- TailwindCSS
+
+**Server:** 
+- Laravel
+- MySQL
+
+## Appendix
+
+Any additional information goes here

--- a/client/pages/forgot-password.tsx
+++ b/client/pages/forgot-password.tsx
@@ -129,4 +129,5 @@ const ForgotPassword = () => {
   );
 };
 
+export { authCheck as getServerSideProps } from 'utils/getServerSideProps';
 export default ForgotPassword;

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -12,3 +12,4 @@ export default function Home() {
   )
 }
 
+export { authCheck as getServerSideProps } from 'utils/getServerSideProps';

--- a/client/pages/sign-in.tsx
+++ b/client/pages/sign-in.tsx
@@ -100,4 +100,5 @@ const SignIn = () => {
   );
 };
 
+export { SignInUpAuthChecker as getServerSideProps } from 'utils/getServerSideProps';
 export default SignIn;

--- a/client/pages/sign-up.tsx
+++ b/client/pages/sign-up.tsx
@@ -99,4 +99,5 @@ const SignUp = () => {
   );
 };
 
+export { SignInUpAuthChecker as getServerSideProps } from 'utils/getServerSideProps';
 export default SignUp;

--- a/client/utils/getServerSideProps.ts
+++ b/client/utils/getServerSideProps.ts
@@ -1,0 +1,83 @@
+import { GetServerSideProps } from 'next';
+
+import { setAuth } from 'redux/auth/authSlice';
+import { wrapper } from 'redux/store';
+import { axios } from 'shared/lib/axios';
+
+export const SignInUpAuthChecker: GetServerSideProps =
+  wrapper.getServerSideProps((store) => async ({ req }) => {
+    const token = req.cookies['token'];
+    const config = { headers: { Authorization: `Bearer ${token}` } };
+
+    try {
+      const res = await axios.get('/auth', config);
+
+      if (res.data) {
+        store.dispatch(setAuth(res.data));
+
+        return {
+          redirect: {
+            permanent: false,
+            destination: '/',
+          },
+          props: req,
+        };
+      }
+    } catch (error: any) {}
+
+    return {
+      props: {},
+    };
+  });
+
+export const authCheck: GetServerSideProps = wrapper.getServerSideProps(
+  (store) =>
+    async ({ req, params }) => {
+      const token = req.cookies['token'];
+      const config = { headers: { Authorization: `Bearer ${token}` } };
+
+      try {
+        const res = await axios.get('/auth', config);
+        store.dispatch(setAuth(res.data));
+
+        const forgotPasswordPage = req.url?.includes('forgot-password');
+        const linkClicked =
+          req.url?.includes('user') && req.url?.includes('verified');
+
+        if (forgotPasswordPage) {
+          if (!token) return { props: {} };
+          if (linkClicked) return { props: {} };
+
+          return {
+            redirect: {
+              permanent: false,
+              destination: '/',
+            },
+          };
+        }
+      } catch (error: any) {
+        const forgotPasswordPage = req.url?.includes('forgot-password');
+
+        if (forgotPasswordPage) return { props: {} };
+        if (error.response.status === 404) {
+          return {
+            notFound: true,
+          };
+        }
+        if (error.response.status === 500) {
+          throw new Error('Internal Server Error');
+        }
+        return {
+          redirect: {
+            permanent: false,
+            destination: '/sign-in',
+          },
+          props: {},
+        };
+      }
+
+      return {
+        props: {},
+      };
+    }
+);


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203234368773394/1203256158175551/f

## Definition of Done
- [ ] User can log in and browse in private routes
- [ ] When the user logs in, they cannot go back to public routes
- [ ] User cannot access user dashboard when not logged in
- [ ] User cannot access user sign-up page when logged in
- [ ] User cannot access user sign-in page when logged in
- [ ] User cannot access user forgot password page when logged in

## Pre-condition
- Try to go inside a private route when you're not logged in
- Try to go in the public route when you're logged in

## Expected Output
- When the user tries to access the private routes when they're not logged in, they should be redirected to the login page
- When the user tries to access the public routes when they're logged in, they should be redirected to the dashboard page

## Screenshots/Recordings
https://user-images.githubusercontent.com/93037350/200186658-8b6f46f2-860e-45ca-8d50-2e5473d8b0ef.mp4

