### PR TITLE
[BarClerk-552] - [BE] Create user forgot password API.

### DIFF
--- a/api/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/api/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Password;
+use App\Http\Requests\ForgotPasswordRequest;
+use App\Http\Resources\ForgotPasswordResource;
+
+class ForgotPasswordController extends Controller
+{
+    public function forgot()
+    {
+        $credentials = request()->validate(['email' => 'required|email']);
+        $res = Password::sendResetLink($credentials);
+        $user = User::where('email', $credentials)->first();
+        return response()->json([
+            "message" => __($res),
+            "status" => $user === null ? 404 : 201
+        ]);
+    }
+
+    public function redirect(Request $request)
+    {
+        $client = env('FRONTEND_URL');
+        $encrypted_token = base64_encode($request->token);
+        $encrypted_email = base64_encode(urldecode($request->email));
+        return redirect("$client/forgot-password?token=$encrypted_token&email=$encrypted_email");
+    }
+
+    public function reset(ForgotPasswordRequest $request)
+    {
+        $decoded_data = ForgotPasswordResource::decodeData($request);
+        $reset_password_status = Password::reset($decoded_data, function ($user, $password) {
+            $user->password = Hash::make($password);
+            $user->save();
+        });
+        if ($reset_password_status == Password::INVALID_TOKEN) {
+            return response()->json(["message" => __(Password::INVALID_TOKEN)], 400);
+        }
+        return response()->json(["message" => "Reset password successfully!"], 201);
+    }
+}

--- a/api/app/Http/Requests/ForgotPasswordRequest.php
+++ b/api/app/Http/Requests/ForgotPasswordRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ForgotPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|string',
+            'token' => 'required|string',
+            'password' => 'required|string|confirmed|min:9'
+        ];
+    }
+}

--- a/api/app/Http/Resources/ForgotPasswordResource.php
+++ b/api/app/Http/Resources/ForgotPasswordResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ForgotPasswordResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public static function decodeData($request)
+    {
+        return [
+            'email' => base64_decode($request->email),
+            'token' => base64_decode($request->token),
+            'password' => $request->password
+        ];
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -30,11 +30,6 @@ Route::group(['prefix' => '/'], function () {
     });
 });
 
-Route::group(['middleware' => 'auth:sanctum', 'prefix' => '/v1'], function () {
-    Route::group(['prefix' => 'user'], function () {
-        Route::get('/', [UserController::class, 'index']);
-        Route::get('/{user}', [UserController::class, 'show']);
-    });
-});
 
-require __DIR__ . '/auth.php';
+require __DIR__ . '/user/auth.php';
+require __DIR__ . '/user/user.php';

--- a/api/routes/user/auth.php
+++ b/api/routes/user/auth.php
@@ -1,13 +1,18 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\Auth\SignUpController;
-use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Auth\ForgotPasswordController;
 
 
 Route::group(['prefix' => '/v1'], function () {
   Route::post('/sign-in', [AuthController::class, 'store']);
   Route::post('/sign-up', [SignUpController::class, 'store']);
+
+  Route::post('/forgot-password', [ForgotPasswordController::class, 'forgot'])->name('password.forgot');
+  Route::get('/redirect', [ForgotPasswordController::class, 'redirect'])->name('password.reset');
+  Route::post('/reset-password', [ForgotPasswordController::class, 'reset']);
 });
 
 Route::group(['middleware' => 'auth:sanctum', 'prefix' => '/v1'], function() {

--- a/api/routes/user/user.php
+++ b/api/routes/user/user.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\UserController;
+
+Route::group(['middleware' => 'auth:sanctum', 'prefix' => '/v1'], function () {
+  Route::group(['prefix' => 'user'], function () {
+    Route::get('/', [UserController::class, 'index']);
+    Route::get('/{user}', [UserController::class, 'show']);
+  });
+});

--- a/client/pages/forgot-password.tsx
+++ b/client/pages/forgot-password.tsx
@@ -16,14 +16,14 @@ import AdminAuthTemplate from "components/templates/AdminAuthTemplate";
 
 const ForgotPassword = () => {
   const { state }: any = Router?.router || {};
-  const { user, verified } = state?.query || {};
+  const { token, email } = state?.query || {};
   const { handleSignInSubmit, ResetLinkSubmit } = useAuthMethods();
   const [isPassHidden, setIsPassHidden] = useState<boolean>(true);
   const [isLinkClicked, setIsLinkClicked] = useState<boolean>(false);
 
   useEffect(() => {
-    setIsLinkClicked((user && verified) ? true : false);
-  }, [user, verified, isLinkClicked]);
+    setIsLinkClicked((token && email) ? true : false);
+  }, [token, email, isLinkClicked]);
 
   const setRequestResetLinkInitialValue = {
     email: "",

--- a/client/utils/getServerSideProps.ts
+++ b/client/utils/getServerSideProps.ts
@@ -42,7 +42,7 @@ export const authCheck: GetServerSideProps = wrapper.getServerSideProps(
 
         const forgotPasswordPage = req.url?.includes('forgot-password');
         const linkClicked =
-          req.url?.includes('user') && req.url?.includes('verified');
+          req.url?.includes('token') && req.url?.includes('email');
 
         if (forgotPasswordPage) {
           if (!token) return { props: {} };


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203234368773394/1203256158175552/f

## Definition of Done
- [ ] Users can receive a reset link on their email address
- [ ] User can successfully reset their password

## Pre-condition
- Input your registered email
- Click the reset link in your email
- Setup new password
- Try to log in with the new password

## Expected Output
- When the user inserts their email, they should receive an email reset password link
- When the user clicks the link, they should be redirected to the set new password page
- When the user sets a new password, they should be able to log in using the new password

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/93037350/200188315-6a3ea097-3067-4dd6-bebc-b485915f3f6c.png)
![image](https://user-images.githubusercontent.com/93037350/200188320-935d3681-993f-49fb-a834-d2f99ffd3139.png)
