### PR TITLE
[BarClerk-944] - [Markup] Create court appearances page with modal

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/line-clamp": "^0.4.2",
     "@tippyjs/react": "^4.2.6",
     "formik": "^2.2.9",
+    "moment": "^2.29.4",
     "next": "13.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/client/src/components/molecules/CourtAppearanceAccordion/EditCourtAppearanceModal.tsx
+++ b/client/src/components/molecules/CourtAppearanceAccordion/EditCourtAppearanceModal.tsx
@@ -1,0 +1,377 @@
+import { useForm } from 'react-hook-form'
+import { Dialog } from '@headlessui/react'
+import React, { FC, useEffect, useState } from 'react'
+import TextareaAutosize from 'react-textarea-autosize'
+import { HiOutlineOfficeBuilding } from 'react-icons/hi'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { Calendar, Clock, Edit, Plus, User, X } from 'react-feather'
+
+import { Spinner } from '~/shared/icons/SpinnerIcon'
+import { ICourtAppearance } from '~/shared/interfaces'
+import DialogBox from '~/components/templates/DialogBox'
+import { CourtAppearanceSchema } from '~/shared/validation'
+import { CourtAppearanceFormValues } from '~/shared/types'
+import CourtChargesIcon from '~/shared/icons/CourtChargeIcon'
+import { useCourtAppearance } from '~/hooks/useCourtAppearance'
+
+type Props = {
+  courtAppearance: ICourtAppearance
+  isOpen: boolean
+  closeModal: () => void
+}
+
+const EditCourtAppearanceModal: FC<Props> = ({
+  courtAppearance,
+  isOpen,
+  closeModal
+}): JSX.Element => {
+  const {
+    reset,
+    register,
+    setError,
+    formState: { errors },
+    handleSubmit
+  } = useForm<CourtAppearanceFormValues>({
+    mode: 'onTouched',
+    resolver: yupResolver(CourtAppearanceSchema)
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        date: courtAppearance?.date,
+        next_court_date: courtAppearance?.nextCourtDate,
+        time: courtAppearance?.time,
+        court: courtAppearance?.court,
+        judicial_officer: courtAppearance?.judicialOfficer,
+        orders: courtAppearance?.orders,
+        other_notes: courtAppearance?.otherNotes
+      })
+    }
+  }, [isOpen])
+
+  const { isLoading, handleEditCourtAppearance } = useCourtAppearance(closeModal, setError)
+
+  return (
+    <DialogBox isOpen={isOpen} closeModal={closeModal}>
+      <Dialog.Panel className="w-full max-w-[812px] transform overflow-hidden rounded-md bg-white text-left align-middle shadow-xl transition-all">
+        <form onSubmit={handleSubmit(handleEditCourtAppearance)}>
+          {/* MODAL HEADER */}
+          <header className="flex items-center justify-between space-x-2 border-b border-slate-300 py-4 px-5">
+            <div className="flex items-center space-x-2">
+              <Plus className="h-5 w-5" />
+              <span className="text-lg font-semibold">Edit Court Appearances</span>
+            </div>
+            <button
+              type="button"
+              onClick={closeModal}
+              className="rounded-md p-0.5 outline-none transition duration-75 ease-in-out hover:bg-slate-100 active:scale-95"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </header>
+          {/* MODAL FORM CONTENT */}
+          <main className="grid grid-cols-2 gap-x-3 gap-y-2 px-8 py-6 pb-10 md:gap-x-5 md:gap-y-4">
+            {/* DATE FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_date" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Date <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30
+                  ${errors?.date && 'border-rose-400 group-focus-within:border-rose-400'}
+                  `}
+                  >
+                    <Calendar
+                      className={`
+                    h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                  
+                  `}
+                    />
+                  </span>
+                  <input
+                    type="date"
+                    {...register('date')}
+                    id="court_appearance_date"
+                    disabled={isLoading}
+                    className={`
+                    w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                    disabled:cursor-not-allowed disabled:opacity-50
+                    ${errors?.date && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400'}
+                  `}
+                  />
+                </div>
+              </label>
+              {errors?.date && <span className="error">{`${errors.date.message}`}</span>}
+            </section>
+            {/* NEXT COURT DATE FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_next_court_date" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Next court date <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30
+                  ${errors?.next_court_date && 'border-rose-400 group-focus-within:border-rose-400'}
+                  `}
+                  >
+                    <Calendar
+                      className={`
+                    h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                    ${errors?.next_court_date && 'text-rose-400 group-focus-within:text-rose-400'}
+                  `}
+                    />
+                  </span>
+                  <input
+                    type="date"
+                    {...register('next_court_date')}
+                    id="court_appearance_next_court_date"
+                    disabled={isLoading}
+                    className={`
+                    w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                    disabled:cursor-not-allowed disabled:opacity-50
+                    ${
+                      errors?.next_court_date &&
+                      'border-rose-400 focus:border-rose-400 focus:ring-rose-400'
+                    }
+                  `}
+                  />
+                </div>
+              </label>
+              {errors?.next_court_date && (
+                <span className="error">{`${errors.next_court_date.message}`}</span>
+              )}
+            </section>
+            {/* TIME FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_time" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  TIME <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30
+                  ${errors?.time && 'border-rose-400 group-focus-within:border-rose-400'}
+                    
+                  `}
+                  >
+                    <Clock
+                      className={`
+                    h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                    ${errors?.time && 'text-rose-400 group-focus-within:text-rose-400'}
+                  
+                  `}
+                    />
+                  </span>
+                  <input
+                    type="time"
+                    {...register('time')}
+                    id="court_appearance_time"
+                    disabled={isLoading}
+                    className={`
+                    w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                    disabled:cursor-not-allowed disabled:opacity-50
+                    
+                  `}
+                  />
+                </div>
+              </label>
+              {errors?.time && <span className="error">{`${errors.time.message}`}</span>}
+            </section>
+            {/* COURT FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_court" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Court <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30
+                  ${errors?.court && 'border-rose-400 group-focus-within:border-rose-400'}
+                    
+                  `}
+                  >
+                    <HiOutlineOfficeBuilding
+                      className={`
+                    h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                    ${errors?.court && 'text-rose-400 group-focus-within:text-rose-400'}
+                  
+                  `}
+                    />
+                  </span>
+                  <input
+                    type="text"
+                    {...register('court')}
+                    id="court_appearance_court"
+                    disabled={isLoading}
+                    className={`
+                    w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                    disabled:cursor-not-allowed disabled:opacity-50
+                    ${errors?.court && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400'}
+                  `}
+                  />
+                </div>
+              </label>
+              {errors?.court && <span className="error">{`${errors.court.message}`}</span>}
+            </section>
+            {/* JUDICIAL OFFICER FIELD */}
+            <section className="col-span-2">
+              <label htmlFor="court_appearance_officer" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Judicial Officer <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30
+                  ${
+                    errors?.judicial_officer && 'border-rose-400 group-focus-within:border-rose-400'
+                  }
+                    
+                  `}
+                  >
+                    <User
+                      className={`
+                    h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                    ${errors?.judicial_officer && 'text-rose-400 group-focus-within:text-rose-400'}
+                  
+                  `}
+                    />
+                  </span>
+                  <input
+                    type="text"
+                    {...register('judicial_officer')}
+                    id="court_appearance_officer"
+                    disabled={isLoading}
+                    className={`
+                    w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                    disabled:cursor-not-allowed disabled:opacity-50
+                    ${
+                      errors?.judicial_officer &&
+                      'border-rose-400 focus:border-rose-400 focus:ring-rose-400'
+                    }
+                  `}
+                  />
+                </div>
+              </label>
+              {errors?.judicial_officer && (
+                <span className="error">{`${errors.judicial_officer.message}`}</span>
+              )}
+            </section>
+            {/* ORDERS FIELD */}
+            <section className="col-span-2">
+              <label htmlFor="court_appearance_orders" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Orders <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative flex">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30 
+                  ${errors?.orders && 'border-rose-400 group-focus-within:border-rose-400'}
+
+                  `}
+                  >
+                    <CourtChargesIcon
+                      className={`
+                    h-5 w-5 fill-current text-slate-300 group-focus-within:text-barclerk-30
+                    ${errors?.orders && 'text-rose-400 group-focus-within:text-rose-400'}
+                  
+                  `}
+                    />
+                  </span>
+                  <TextareaAutosize
+                    {...register('orders')}
+                    id="court_appearance_orders"
+                    disabled={isLoading}
+                    className={`
+                    min-h-[70px] w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30
+                    focus:ring-barclerk-30 disabled:cursor-not-allowed disabled:opacity-50
+                    ${errors?.orders && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400'}
+
+                  `}
+                  />
+                </div>
+              </label>
+              {errors?.orders && <span className="error">{`${errors.orders.message}`}</span>}
+            </section>
+            {/* OTHER NOTES FIELD */}
+            <section className="col-span-2">
+              <label htmlFor="court_appearance_notes" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Other Notes <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative flex">
+                  <span
+                    className={`
+                    absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                  group-focus-within:border-barclerk-30
+                  `}
+                  >
+                    <Edit
+                      className={`
+                    h-5 w-5 text-slate-300 group-focus-within:text-barclerk-30
+                  
+                  `}
+                    />
+                  </span>
+                  <TextareaAutosize
+                    {...register('other_notes')}
+                    id="court_appearance_notes"
+                    disabled={isLoading}
+                    className={`
+                    min-h-[70px] w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30
+                    focus:ring-barclerk-30 disabled:cursor-not-allowed disabled:opacity-50
+                  `}
+                  />
+                </div>
+              </label>
+            </section>
+          </main>
+          {/* MODAL FOOTER SUBMIT AND CANCEL BUTTON */}
+          <footer className="flex justify-end space-x-3 border-t border-slate-300 bg-slate-50 py-4 px-4">
+            <button
+              type="button"
+              onClick={closeModal}
+              disabled={isLoading}
+              className={`
+              w-36 rounded border border-slate-300 bg-white 
+            text-slate-600 outline-none transition duration-75 ease-in-out
+              disabled:cursor-not-allowed disabled:opacity-50 hover:border-slate-400 hover:bg-white
+            hover:text-slate-700 active:scale-95 disabled:active:scale-100
+            `}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className={`
+              flex w-36 items-center justify-center rounded bg-barclerk-10 py-2 text-white 
+              outline-none transition duration-75 ease-in-out focus:bg-barclerk-10/90 disabled:cursor-not-allowed disabled:opacity-50
+              hover:bg-barclerk-10/90 disabled:hover:bg-barclerk-10 active:scale-95 disabled:active:scale-100
+            `}
+            >
+              {isLoading ? <Spinner className="h-6 w-6" /> : 'Save'}
+            </button>
+          </footer>
+        </form>
+      </Dialog.Panel>
+    </DialogBox>
+  )
+}
+
+export default EditCourtAppearanceModal

--- a/client/src/components/molecules/CourtAppearanceAccordion/index.tsx
+++ b/client/src/components/molecules/CourtAppearanceAccordion/index.tsx
@@ -1,0 +1,134 @@
+import { FC, useState } from 'react'
+import { ChevronDown, Edit } from 'react-feather'
+import moment from 'moment'
+
+import EditCourtAppearanceModal from './EditCourtAppearanceModal'
+import { ICourtAppearance } from '~/shared/interfaces/index'
+
+type Props = {
+  courtAppearance: ICourtAppearance
+}
+
+const CourtAppearanceAccordion: FC<Props> = ({ courtAppearance }) => {
+  const [show, setShow] = useState<{id: number; show: boolean}>({ id: 0, show: false })
+  const [showEditModal, setShowEditModal] = useState<boolean>(false)
+
+  return (
+    <>
+      <div className="group hover:shadow-lg">
+        <AccordionHeader
+          setShowEditModal={setShowEditModal}
+          courtAppearance={courtAppearance}
+          show={show}
+          setShow={setShow}
+        />
+        {show?.show === true && show?.id === courtAppearance?.id && (
+          <AccordionBody orders={courtAppearance?.orders} notes={courtAppearance?.otherNotes} />
+        )}
+      </div>
+      <EditCourtAppearanceModal
+        courtAppearance={courtAppearance}
+        isOpen={showEditModal}
+        closeModal={() => setShowEditModal(false)}
+      />
+    </>
+  )
+}
+
+const AccordionHeader = ({
+  courtAppearance,
+  show,
+  setShow,
+  setShowEditModal
+}: {
+  courtAppearance: ICourtAppearance
+  show: { id: number; show: boolean }
+  setShow: ({id, show}: {id: number, show:boolean}) => void
+  setShowEditModal: (value: boolean) => void
+}): JSX.Element => {
+  return (
+    <div
+      className={`mb-[2px] flex w-full justify-between ${
+        !show?.show && 'rounded-sm'
+      } rounded-t-sm bg-white py-3 pl-6 pr-5 text-sm shadow transition duration-150 ease-in-out`}
+    >
+      <div className="flex space-x-16 overflow-hidden whitespace-nowrap px-2 text-xs">
+        <div className="flex flex-col space-y-1">
+          <div>Date</div>
+          <div className="font-extrabold text-barclerk-30">{moment(courtAppearance?.date).format("D MMMM YYYY")}</div>
+        </div>
+        <div className="flex flex-col space-y-1">
+          <div className="text-slate-500">Time</div>
+          <div className=" text-barclerk-10">{moment(`${courtAppearance?.date} ${courtAppearance?.time}`).format('hh:mm A')}</div>
+        </div>
+        <div className="flex flex-col space-y-1">
+          <div className="text-slate-500">Court</div>
+          <div className=" text-barclerk-10">{courtAppearance?.court}</div>
+        </div>
+        <div className="flex flex-col space-y-1">
+          <div className="text-slate-500">Judicial Officer</div>
+          <div className=" text-barclerk-10">{courtAppearance?.judicialOfficer}</div>
+        </div>
+        <div className="flex flex-col space-y-1">
+          <div>Next Court Date</div>
+          <div className="font-extrabold text-barclerk-30">{moment(courtAppearance?.nextCourtDate).format("D MMMM YYYY")}</div>
+        </div>
+      </div>
+      <div className="flex items-center pl-4">
+        <button onClick={() => setShowEditModal(true)} className="rounded p-2">
+          <Edit className="h-5 w-5 font-light" />
+        </button>
+
+        <button
+          onClick={
+            show?.show
+              ? () => setShow({ id: 0, show: false })
+              : () => setShow({ id: courtAppearance?.id, show: true })
+          }
+          className={`rounded p-1 ${
+            show?.id === courtAppearance?.id && show?.show && 'rotate-180'
+          }`}
+        >
+          <ChevronDown className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const AccordionBody = ({ orders, notes }: { orders?: string; notes?: string }): JSX.Element => {
+  return (
+    <div className="flex w-full justify-between space-x-10 rounded-b-sm bg-white py-3 pl-6 pr-14 pb-12 text-xs shadow transition duration-150 ease-in-out">
+      <div className="flex w-1/2 flex-col space-y-2">
+        <div>Orders</div>
+        <div className="flex max-h-52 flex-1 overflow-y-auto rounded border border-slate-300 p-4">
+          {orders ? (
+            <>
+              {orders}
+            </>
+          ) : (
+            <div className="flex w-full items-center justify-center font-semibold text-failed">
+              No available data.
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="flex w-1/2 flex-col space-y-2">
+        <div>Other notes</div>
+        <div className="flex max-h-52 flex-1 overflow-y-auto rounded font-semibold border border-slate-300 p-4">
+          {notes ? (
+            <>
+              <p>{notes}</p>
+            </>
+          ) : (
+            <div className="flex w-full items-center justify-center font-semibold text-failed">
+              No available data.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CourtAppearanceAccordion

--- a/client/src/components/molecules/CourtAppearanceList/AddNewCourtAppearance.tsx
+++ b/client/src/components/molecules/CourtAppearanceList/AddNewCourtAppearance.tsx
@@ -1,0 +1,376 @@
+import React, { FC, useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { Dialog } from '@headlessui/react'
+import TextareaAutosize from 'react-textarea-autosize'
+import { HiOutlineOfficeBuilding } from 'react-icons/hi'
+import { Calendar, Clock, Edit, Plus, User, X } from 'react-feather'
+
+import { useCourtAppearance } from '~/hooks/useCourtAppearance'
+import { Spinner } from '~/shared/icons/SpinnerIcon'
+import DialogBox from '~/components/templates/DialogBox'
+import { CourtAppearanceFormValues } from '~/shared/types'
+import { CourtAppearanceSchema } from '~/shared/validation'
+import CourtChargesIcon from '~/shared/icons/CourtChargeIcon'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+}
+
+const AddNewCourtAppearanceModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+  // TODO: Add Form Values and logic in FE Integration
+  const {
+    reset,
+    register,
+    setError,
+    formState: { errors },
+    handleSubmit
+  } = useForm<CourtAppearanceFormValues>({
+    mode: 'onTouched',
+    resolver: yupResolver(CourtAppearanceSchema)
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        date: '',
+        next_court_date: '',
+        time: '',
+        court: '',
+        judicial_officer: '',
+        orders: '',
+        other_notes: ''
+      })
+    }
+  }, [isOpen])
+
+  const { isLoading, handleAddCourtAppearance } = useCourtAppearance(closeModal, setError)
+
+  return (
+    <DialogBox isOpen={isOpen} closeModal={closeModal}>
+      <Dialog.Panel className="w-full max-w-[812px] transform overflow-hidden rounded-md bg-white text-left align-middle shadow-xl transition-all">
+        <form onSubmit={handleSubmit(handleAddCourtAppearance)}>
+          {/* MODAL HEADER */}
+          <header className="flex items-center justify-between space-x-2 border-b border-slate-300 py-4 px-5">
+            <div className="flex items-center space-x-2">
+              <Plus className="h-5 w-5" />
+              <span className="text-lg font-semibold">Add Court Appearances</span>
+            </div>
+            <button
+              type="button"
+              onClick={closeModal}
+              className="rounded-md p-0.5 outline-none transition duration-75 ease-in-out hover:bg-slate-100 active:scale-95"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </header>
+          {/* MODAL FORM CONTENT */}
+          <main className="grid grid-cols-2 gap-x-3 gap-y-2 px-8 py-6 pb-10 text-sm md:gap-x-5 md:gap-y-4">
+            {/* DATE FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_date" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Date <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                      ${errors?.date && 'border-rose-400 group-focus-within:border-rose-400'}
+                      
+                    `}
+                  >
+                    <Calendar
+                      className={`
+                      h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                      ${errors?.date && 'text-rose-400 group-focus-within:text-rose-400'}
+                    
+                    `}
+                    />
+                  </span>
+                  <input
+                    type="date"
+                    id="court_appearance_date"
+                    {...register('date')}
+                    disabled={isLoading}
+                    className={`
+                      w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                      disabled:cursor-not-allowed disabled:opacity-50 
+                      ${errors?.date && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400'}
+                    `}
+                  />
+                </div>
+              </label>
+              {errors?.date && <span className="error">{`${errors.date.message}`}</span>}
+            </section>
+            {/* NEXT COURT DATE FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_next_court_date" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Next court date <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                    ${
+                      errors?.next_court_date &&
+                      'border-rose-400 group-focus-within:border-rose-400'
+                    }
+                    `}
+                  >
+                    <Calendar
+                      className={`
+                      h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                      ${errors?.next_court_date && 'text-rose-400 group-focus-within:text-rose-400'}
+                    
+                    `}
+                    />
+                  </span>
+                  <input
+                    type="date"
+                    id="court_appearance_next_court_date"
+                    {...register('next_court_date')}
+                    disabled={isLoading}
+                    className={`
+                      w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                      disabled:cursor-not-allowed disabled:opacity-50
+                      ${
+                        errors?.next_court_date &&
+                        'border-rose-400 focus:border-rose-400 focus:ring-rose-400'
+                      }
+                    `}
+                  />
+                </div>
+              </label>
+              {errors?.next_court_date && (
+                <span className="error">{`${errors.next_court_date.message}`}</span>
+              )}
+            </section>
+            {/* TIME FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_time" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  TIME <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                    ${errors?.time && 'border-rose-400 group-focus-within:border-rose-400'}
+                    `}
+                  >
+                    <Clock
+                      className={`
+                      h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                      ${errors?.time && 'text-rose-400 group-focus-within:text-rose-400'}
+                    
+                    `}
+                    />
+                  </span>
+                  <input
+                    type="time"
+                    id="court_appearance_time"
+                    {...register('time')}
+                    disabled={isLoading}
+                    className={`
+                      w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                      disabled:cursor-not-allowed disabled:opacity-50
+                      ${errors?.time && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400'}
+                    `}
+                  />
+                </div>
+              </label>
+              {errors?.time && <span className="error">{`${errors.time.message}`}</span>}
+            </section>
+            {/* COURT FIELD */}
+            <section className="col-span-1">
+              <label htmlFor="court_appearance_court" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Court <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                    ${errors?.court && 'border-rose-400 group-focus-within:border-rose-400'}
+                    `}
+                  >
+                    <HiOutlineOfficeBuilding
+                      className={`
+                      h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                      ${errors?.court && 'text-rose-400 group-focus-within:text-rose-400'}
+                    `}
+                    />
+                  </span>
+                  <input
+                    type="text"
+                    id="court_appearance_court"
+                    {...register('court')}
+                    disabled={isLoading}
+                    className={`
+                      w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                      disabled:cursor-not-allowed disabled:opacity-50
+                      ${
+                        errors?.court && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400'
+                      }
+                    `}
+                  />
+                </div>
+              </label>
+              {errors?.court && <span className="error">{`${errors.court.message}`}</span>}
+            </section>
+            {/* JUDICIAL OFFICER FIELD */}
+            <section className="col-span-2">
+              <label htmlFor="court_appearance_officer" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Judicial Officer <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                    ${
+                      errors?.judicial_officer &&
+                      'border-rose-400 group-focus-within:border-rose-400'
+                    }
+                    `}
+                  >
+                    <User
+                      className={`
+                      h-5 w-5 text-slate-300  group-focus-within:text-barclerk-30
+                      ${
+                        errors?.judicial_officer && 'text-rose-400 group-focus-within:text-rose-400'
+                      }
+                    `}
+                    />
+                  </span>
+                  <input
+                    type="text"
+                    id="court_appearance_officer"
+                    {...register('judicial_officer')}
+                    disabled={isLoading}
+                    className={`
+                      w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30 focus:ring-barclerk-30
+                      disabled:cursor-not-allowed disabled:opacity-50
+                      ${
+                        errors?.judicial_officer &&
+                        'border-rose-400 focus:border-rose-400 focus:ring-rose-400'
+                      }
+                    `}
+                  />
+                </div>
+              </label>
+              {errors?.judicial_officer && (
+                <span className="error">{`${errors.judicial_officer.message}`}</span>
+              )}
+            </section>
+            {/* ORDERS FIELD */}
+            <section className="col-span-2">
+              <label htmlFor="court_appearance_orders" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">
+                  Orders <span className="text-rose-500">*</span>
+                </h2>
+                <div className="group relative flex">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                    ${errors?.orders && 'border-rose-400 group-focus-within:border-rose-400'}
+                    `}
+                  >
+                    <CourtChargesIcon
+                      className={`
+                      h-5 w-5 fill-current text-slate-300 group-focus-within:text-barclerk-30
+                      ${errors?.orders && 'text-rose-400 group-focus-within:text-rose-400'}
+                    `}
+                    />
+                  </span>
+                  <TextareaAutosize
+                    id="court_appearance_orders"
+                    {...register('orders')}
+                    disabled={isLoading}
+                    className={`
+                      min-h-[70px] w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30
+                      focus:ring-barclerk-30 disabled:cursor-not-allowed disabled:opacity-50
+                      ${
+                        errors?.orders &&
+                        'border-rose-400 focus:border-rose-400 focus:ring-rose-400'
+                      }
+                    `}
+                  />
+                </div>
+              </label>
+              {errors?.orders && <span className="error">{`${errors.orders.message}`}</span>}
+            </section>
+            {/* OTHER NOTES FIELD */}
+            <section className="col-span-2">
+              <label htmlFor="court_appearance_notes" className="flex flex-col space-y-1">
+                <h2 className="text-sm text-slate-700">Other Notes</h2>
+                <div className="group relative flex">
+                  <span
+                    className={`
+                      absolute inset-y-0 flex items-center border-r-2 border-slate-300 px-2.5 
+                    group-focus-within:border-barclerk-30
+                    `}
+                  >
+                    <Edit
+                      className={`
+                      h-5 w-5 text-slate-300 group-focus-within:text-barclerk-30
+                    
+                    `}
+                    />
+                  </span>
+                  <TextareaAutosize
+                    id="court_appearance_notes"
+                    {...register('other_notes')}
+                    disabled={isLoading}
+                    className={`
+                      min-h-[70px] w-full rounded-md border-2 border-slate-300 pl-12 focus:border-barclerk-30
+                      focus:ring-barclerk-30 disabled:cursor-not-allowed disabled:opacity-50
+                    `}
+                  />
+                </div>
+              </label>
+            </section>
+          </main>
+          {/* MODAL FOOTER SUBMIT AND CANCEL BUTTON */}
+          <footer className="flex justify-end space-x-3 border-t border-slate-300 bg-slate-50 py-4 px-4">
+            <button
+              type="button"
+              onClick={closeModal}
+              disabled={isLoading}
+              className={`
+                w-36 rounded border border-slate-300 bg-white 
+              text-slate-600 outline-none transition duration-75 ease-in-out
+                disabled:cursor-not-allowed disabled:opacity-50 hover:border-slate-400 hover:bg-white
+              hover:text-slate-700 active:scale-95 disabled:active:scale-100
+              `}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className={`
+                flex w-36 items-center justify-center rounded bg-barclerk-10 py-2 text-white 
+                outline-none transition duration-75 ease-in-out focus:bg-barclerk-10/90 disabled:cursor-not-allowed disabled:opacity-50
+                hover:bg-barclerk-10/90 disabled:hover:bg-barclerk-10 active:scale-95 disabled:active:scale-100
+              `}
+            >
+              {isLoading ? <Spinner className="h-6 w-6" /> : 'Save'}
+            </button>
+          </footer>
+        </form>
+      </Dialog.Panel>
+    </DialogBox>
+  )
+}
+
+export default AddNewCourtAppearanceModal

--- a/client/src/components/molecules/CourtAppearanceList/index.tsx
+++ b/client/src/components/molecules/CourtAppearanceList/index.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import ReactPaginate from 'react-paginate'
+
+import CourtAppearanceAccordion from '../CourtAppearanceAccordion'
+import { ICourtAppearance } from '~/shared/interfaces'
+
+const CourtAppearancesList = ({
+  courtAppearances
+}: {
+  courtAppearances: ICourtAppearance[]
+}): JSX.Element => {
+  const [pageNumber, setPageNumber] = useState<number>(0)
+
+  const listPerPage = 5
+  const pagesVisited = pageNumber * listPerPage
+
+  const displayCourtAppearances = courtAppearances?.slice(pagesVisited, pagesVisited + listPerPage)
+
+  const pageCount = Math.ceil(courtAppearances?.length / listPerPage)
+
+  const handlePageChange = ({ selected }: { selected: number }): void => setPageNumber(selected)
+
+  return (
+    <>
+      {displayCourtAppearances?.map((courtAppearance) => {
+        return (
+          <div key={courtAppearance?.id}>
+            <CourtAppearanceAccordion courtAppearance={courtAppearance} />
+          </div>
+        )
+      })}
+      {pageCount > 1 && (
+        <section className="paginate-section text-gray-500">
+          <ReactPaginate
+            previousLabel="Prev"
+            nextLabel="Next"
+            pageCount={pageCount}
+            onPageChange={handlePageChange}
+            containerClassName="inline-flex -space-x-px text-sm"
+            previousLinkClassName="paginate-link rounded-l-md"
+            pageLinkClassName="paginate-link"
+            activeClassName="paginate-link-active"
+            nextLinkClassName="paginate-link rounded-r-md"
+          />
+        </section>
+      )}
+    </>
+  )
+}
+
+export default CourtAppearancesList

--- a/client/src/hooks/useCourtAppearance.ts
+++ b/client/src/hooks/useCourtAppearance.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { UseFormSetError } from 'react-hook-form'
+
+import { useAppDispatch } from './reduxSelector'
+import { CourtAppearanceFormValues } from '../shared/types/index'
+
+export const useCourtAppearance = (closeModal: () => void, setError?: UseFormSetError<CourtAppearanceFormValues>) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const dispatch = useAppDispatch() 
+
+  const handleAddCourtAppearance = (data: CourtAppearanceFormValues) => { 
+    setIsLoading(() => true)
+    toast.success('New Court Appearance created successfully!')
+    closeModal()
+    setIsLoading(() => false)
+  }
+  
+  const handleEditCourtAppearance = (data: CourtAppearanceFormValues) => {
+    setIsLoading(() => true)
+    toast.success('Edited Court Appearance successfully!')
+    closeModal()
+    setIsLoading(() => false)
+  }
+
+  return {
+    handleAddCourtAppearance,
+    handleEditCourtAppearance,
+    isLoading
+  }
+}

--- a/client/src/pages/matter/[id]/court-appearances.tsx
+++ b/client/src/pages/matter/[id]/court-appearances.tsx
@@ -1,17 +1,126 @@
-import React from 'react'
+import React, { ReactNode, useState } from 'react'
 import { NextPage } from 'next'
+import { Plus } from 'react-feather'
 
 import MatterLayout from '~/components/templates/MatterLayout'
+import BreedCrumb from '~/components/atoms/Breedcrumb'
+import CourtAppearancesList from '~/components/molecules/CourtAppearanceList'
+import AddNewCourtAppearanceModal from '~/components/molecules/CourtAppearanceList/AddNewCourtAppearance'
 
 const CourtAppearances: NextPage = (): JSX.Element => {
+  // sampleCourtAppearances JSON file
+  const sampleCourtAppearances = [
+    {
+      id: 1,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: `Home D granted, at Mum's address $10k Surety only to be signed by Mum and $5k personal undertaking. Not allowed to go within 500 ms of points of international or domestic departure.`,
+      otherNotes:
+        'Lorem ipsum dolor sit amet consectetur adipisicing elit. Maxime pariatur unde dolorum alias est fuga enim delectus ipsum beatae in asperiores sed magnam laudantium deleniti repellendus, eveniet rem itaque maiores at accusamus odit nesciunt voluptatibus, amet ducimus? Beatae maiores inventore eos blanditiis accusamus minima repellat animi rerum, dolore aliquid ipsam nam? Facilis odit dicta laborum quaerat beatae commodi. Adipisci temporibus tempore corporis delectus ab et voluptatibus ut distinctio excepturi! Iste sed rerum vero libero ipsa! Sunt quis ipsam soluta dolor omnis saepe fugiat officia voluptas suscipit est quam impedit eum, aspernatur labore incidunt. Perspiciatis repellendus consectetur incidunt, fugit in quasi voluptas aliquid laudantium cum quis necessitatibus expedita architecto atque excepturi temporibus id odio. Sequi, quas quia! Aperiam saepe provident vitae?'
+    },
+    {
+      id: 2,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: 'Home D Report.',
+      otherNotes: ''
+    },
+    {
+      id: 3,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: 'Home D Report.',
+      otherNotes: ''
+    },
+    {
+      id: 4,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: 'Home D Report.',
+      otherNotes: ''
+    },
+    {
+      id: 5,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: 'Home D Report.',
+      otherNotes: ''
+    },
+    {
+      id: 6,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: 'Home D Report.',
+      otherNotes: ''
+    },
+    {
+      id: 7,
+      date: '2022-06-06',
+      time: '11:11',
+      court: 'District Court',
+      judicialOfficer: 'Ayling',
+      nextCourtDate: '2022-06-12',
+      orders: 'Home D Report.',
+      otherNotes: ''
+    }
+  ]
+
   return (
     <MatterLayout metaTitle="Court Appearances">
-      <div className="flex h-full items-center justify-center px-8">
-        <div className="mx-auto min-h-[90vh] w-full max-w-6xl rounded-lg bg-white p-8 shadow">
-          This is the Court Appearances
-        </div>
-      </div>
+      <CourtAppearancesLayout>
+        <BreedCrumb route="Court Appearances" />
+        <CourtAppearancesHeader />
+        <CourtAppearancesList courtAppearances={sampleCourtAppearances} />
+      </CourtAppearancesLayout>
     </MatterLayout>
+  )
+}
+
+const CourtAppearancesLayout = ({ children }: { children: ReactNode }): JSX.Element => (
+  <section className="mx-auto h-full w-full space-y-2 p-4 md:px-12">{children}</section>
+)
+
+const CourtAppearancesHeader = (): JSX.Element => {
+  const [showModal, setShowModal] = useState<boolean>(false)
+
+  return (
+    <div className="flex items-center justify-between py-4 md:py-6">
+      <h1 className="text-xl font-semibold text-barclerk-10 lg:text-2xl">Court Appearances</h1>
+      <div className="flex flex-wrap items-center space-x-5">
+        <button
+          type="button"
+          className={`
+            flex cursor-pointer items-center space-x-1 rounded border border-barclerk-10 bg-barclerk-10 px-2 py-[0.26rem] text-sm
+          text-white shadow outline-none transition duration-150 ease-in-out focus:bg-barclerk-10 hover:bg-barclerk-10 hover:bg-barclerk-10/90
+            active:scale-95 active:bg-barclerk-10
+          `}
+          title="Add New Matter"
+          onClick={() => setShowModal(true)}
+        >
+          <Plus className="h-4 w-4" />
+          <span className="hidden md:block">Add New Data</span>
+        </button>
+        <AddNewCourtAppearanceModal isOpen={showModal} closeModal={() => setShowModal(false)} />
+      </div>
+    </div>
   )
 }
 

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -32,6 +32,17 @@ export interface IClientProfile {
   lastCourtDates?: ILastCourtDates[]
 }
 
+export interface ICourtAppearance {
+  id: number
+  date?: string
+  time?: string
+  court?: string
+  judicialOfficer?: string
+  nextCourtDate?: string
+  orders?: string
+  otherNotes?: string
+}
+
 export interface ILastCourtDates {
   id: number
   date: string

--- a/client/src/shared/types/index.ts
+++ b/client/src/shared/types/index.ts
@@ -48,6 +48,17 @@ export type MatterFormValues = {
   in_custody_location: string
   value?: string
 }
+
+export type CourtAppearanceFormValues = {
+  date: string
+  next_court_date: string
+  time: string
+  court: string
+  judicial_officer: string
+  orders: string
+  other_notes?: string
+}
+
 export type Profile = {
   first_name: string
   last_name: string

--- a/client/src/shared/validation/index.ts
+++ b/client/src/shared/validation/index.ts
@@ -54,6 +54,16 @@ export const MatterFormSchema = Yup.object().shape({
   in_custody_location: Yup.string().max(255)
 })
 
+export const CourtAppearanceSchema = Yup.object().shape({
+    date: Yup.string().max(255).required('Must be a valid date'),
+    next_court_date: Yup.string().max(255).required('Must be a valid date'),
+    time: Yup.string().max(255).required('Must be a valid time'),
+    court: Yup.string().max(255).required('This field is required'),
+    judicial_officer: Yup.string().max(255).required('This field is required'),
+    orders: Yup.string().required('This field is required'),
+    other_notes: Yup.string(),
+})
+
 export const ProfileFormSchema = Yup.object().shape({
   first_name: Yup.string().required('First name is required'),
   last_name: Yup.string().required('Last name is required'),

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6201,6 +6201,11 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203234368773394/1203256371568944

## Note
- [ ] momentJS installed for dateTime to String conversion

## Definition of Done
- [ ] Add markup for Court Appearances page
  - [ ] Add `court appearance accordion`
  - [ ] Add `edit court appearance modal`
  - [ ] Add `add court appearance` modal

## Pre-condition
- 

## Expected Output
  - When user clicks `View More` on Client Profile page, they will be redirected to the Court Appearances page
  - When user clicks on the chevronDown icon on CourtAppearanceAccordion, the accordion body will appear
  - When user clicks on editIcon for a CourtAppearanceAccordion, the editCourtAppearance Modal appears with the provided data (form submission to be added on FE Integration)
  - When the user clicks `Add Court Appearance` on the header, the AddCourtAppearance modal appears.
  - Pagination is added. Maximum of 5 items are visible per page.

## Screenshots/Recordings
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/118783823/205028991-aefb03f5-af59-4622-9039-cc33fc594eba.png">
<img width="914" alt="image" src="https://user-images.githubusercontent.com/118783823/205029034-ce830fb9-cea2-4e8f-aa5c-f4a34ce52f09.png">
<img width="894" alt="image" src="https://user-images.githubusercontent.com/118783823/205029080-e3b78762-cc77-47c8-8759-d6f03ce2e87c.png">

