### PR TITLE
[BarClerk-948] - [FE] Integrate Get all clients/matter info in profil…

### DIFF
--- a/api/app/Models/Client.php
+++ b/api/app/Models/Client.php
@@ -197,7 +197,7 @@ class Client extends Model
 
         return [
             'preparation' => $grant->timeEntries()->preparation()->firstOr('amount', fn () => 0),
-            'otherTypes' => $grant->timeEntries()->otherTypes()->sum('amount'),
+            'other_types' => $grant->timeEntries()->otherTypes()->sum('amount'),
             'attendance' => $grant->timeEntries()->attendance()->sum('amount'),
             'total_fund' => $totalFund,
             'total_fund_used' => round($totalFundUsed, 2),

--- a/client/src/components/molecules/ClientProfileCard/CardSkeleton.tsx
+++ b/client/src/components/molecules/ClientProfileCard/CardSkeleton.tsx
@@ -1,0 +1,170 @@
+import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
+
+export const CardSkeleton = () => {
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <div className="mt-2 mb-4 hidden sm:flex">
+        <LineSkeleton className="h-5 w-52" />
+      </div>
+      {/* ProfileHeader */}
+      <div className="my-2 flex justify-between">
+        <LineSkeleton className="h-5 w-72" />
+        <LineSkeleton className="h-5 w-40" />
+      </div>
+      {/* ProfileCard */}
+      <div className="flex w-full flex-col  space-y-6 md:flex-row md:space-y-0 md:justify-between">
+        <div className="space-y-6 md:mr-12 md:flex md:flex-col md:w-1/2 md:overflow-hidden">
+          {/* ProfileInfo */}
+          <div className="space-y-7 rounded-lg bg-white px-5 py-5">
+            <LineSkeleton className="h-5 w-52" />
+            <div className="flex justify-between">
+              <div className="flex w-1/3 flex-col space-y-1">
+                <LineSkeleton className="w-24 p-2 md:w-1/2" />
+                <LineSkeleton className="w-14 p-1.5 md:w-3/4" />
+              </div>
+              <div className="flex w-1/3 flex-col space-y-1">
+                <LineSkeleton className="w-24 p-2 md:w-1/2" />
+                <LineSkeleton className="w-14 p-1.5 md:w-3/4" />
+              </div>
+              <div className="flex w-1/3 flex-col space-y-1">
+                <LineSkeleton className="w-20 p-2 md:w-1/2" />
+                <LineSkeleton className="w-20 p-1.5 md:w-3/4" />
+              </div>
+            </div>
+            <div className="flex flex-col">
+              <LineSkeleton className="w-20 p-2" />
+              <LineSkeleton className="w-52 p-1.5" />
+            </div>
+            <div className="flex flex-col">
+              <LineSkeleton className="w-20 p-2" />
+              <div className="ml-4">
+                <LineSkeleton className="w-32 p-1.5" />
+                <LineSkeleton className="w-32 p-1.5" />
+                <LineSkeleton className="w-40 p-1.5" />
+                <LineSkeleton className="w-28 p-1.5" />
+              </div>
+            </div>
+          </div>
+          {/* ProfileFunds */}
+          <div className="space-y-1 rounded-lg bg-white px-5 py-5 md:grid md:grid-cols-3 md:space-y-0">
+            <div className="flex justify-between md:col-span-1 md:flex-col">
+              <LineSkeleton className="w-32 p-1.5 md:w-1/2" />
+              <LineSkeleton className="w-28 p-1.5 md:w-3/4" />
+            </div>
+            <div className="flex justify-between md:col-span-1 md:flex-col">
+              <LineSkeleton className="w-28 p-1.5 md:w-1/2" />
+              <LineSkeleton className="w-32 p-1.5 md:w-3/4" />
+            </div>
+            <div className="flex justify-between md:col-span-1 md:flex-col">
+              <LineSkeleton className="w-40 p-1.5 md:w-1/2" />
+              <LineSkeleton className="w-32 p-1.5 md:w-3/4" />
+            </div>
+          </div>
+          {/* ProfileOthers */}
+          <div className="space-y-1 rounded-lg bg-white px-5 py-5 md:grid md:grid-cols-3 md:space-y-0">
+            <div className="flex justify-between md:col-span-1 md:flex-col">
+              <LineSkeleton className="w-32 p-1.5 md:w-1/2" />
+              <LineSkeleton className="w-28 p-1.5 md:w-3/4" />
+            </div>
+            <div className="flex justify-between md:col-span-1 md:flex-col">
+              <LineSkeleton className="w-28 p-1.5 md:w-1/2" />
+              <LineSkeleton className="w-32 p-1.5 md:w-3/4" />
+            </div>
+            <div className="flex justify-between md:col-span-1 md:flex-col">
+              <LineSkeleton className="w-40 p-1.5 md:w-1/2" />
+              <LineSkeleton className="w-32 p-1.5 md:w-3/4" />
+            </div>
+          </div>
+        </div>
+
+        {/* CourtInfo */}
+        <div className="md:flex md:flex-col md:w-1/2 md:space-y-6 md:overflow-hidden">
+          <div className="rounded-lg bg-white px-5 py-5">
+            <div className="flex items-center justify-between">
+              <LineSkeleton className="w-32 p-1.5" />
+              <LineSkeleton className="w-28 p-1.5" />
+            </div>
+          </div>
+          {/* LastCourtDates */}
+          <div className="rounded-lg bg-white px-5 py-5">
+            <div className="flex flex-col">
+              <div className="mb-5 border-b-2 pb-2">
+                <LineSkeleton className="w-40 p-1.5" />
+              </div>
+              <div className="flex flex-col space-y-5 border-b-2 py-5">
+                <div className="flex flex-col">
+                  <div className="flex space-x-2">
+                    <div className="w-16">
+                      <LineSkeleton className="" />
+                    </div>
+                    <div className="flex w-full">
+                      <LineSkeleton className="w-32" />
+                    </div>
+                  </div>
+                  <div className="flex space-x-2">
+                    <div className="w-16">
+                      <LineSkeleton className="" />
+                    </div>
+                    <div className="flex w-full flex-col">
+                      <LineSkeleton className="w-10/12 p-1" />
+                      <LineSkeleton className="w-11/12 p-1" />
+                      <LineSkeleton className="w-8/12 p-1" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-col space-y-5 border-b-2 py-5">
+                <div className="flex flex-col">
+                  <div className="flex space-x-2">
+                    <div className="w-16">
+                      <LineSkeleton className="" />
+                    </div>
+                    <div className="flex w-full">
+                      <LineSkeleton className="w-32" />
+                    </div>
+                  </div>
+                  <div className="flex space-x-2">
+                    <div className="w-16">
+                      <LineSkeleton className="" />
+                    </div>
+                    <div className="flex w-full flex-col">
+                      <LineSkeleton className="w-10/12 p-1" />
+                      <LineSkeleton className="w-11/12 p-1" />
+                      <LineSkeleton className="w-8/12 p-1" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-col space-y-5 border-b-2 py-5">
+                <div className="flex flex-col">
+                  <div className="flex space-x-2">
+                    <div className="w-16">
+                      <LineSkeleton className="" />
+                    </div>
+                    <div className="flex w-full">
+                      <LineSkeleton className="w-32" />
+                    </div>
+                  </div>
+                  <div className="flex space-x-2">
+                    <div className="w-16">
+                      <LineSkeleton className="" />
+                    </div>
+                    <div className="flex w-full flex-col">
+                      <LineSkeleton className="w-10/12 p-1" />
+                      <LineSkeleton className="w-11/12 p-1" />
+                      <LineSkeleton className="w-8/12 p-1" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="mt-5 flex w-full justify-center">
+              <LineSkeleton className="w-24" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/molecules/CourtAppearanceAccordion/EditCourtAppearanceModal.tsx
+++ b/client/src/components/molecules/CourtAppearanceAccordion/EditCourtAppearanceModal.tsx
@@ -40,12 +40,12 @@ const EditCourtAppearanceModal: FC<Props> = ({
     if (isOpen) {
       reset({
         date: courtAppearance?.date,
-        next_court_date: courtAppearance?.nextCourtDate,
+        next_court_date: courtAppearance?.next_court_date,
         time: courtAppearance?.time,
         court: courtAppearance?.court,
-        judicial_officer: courtAppearance?.judicialOfficer,
+        judicial_officer: courtAppearance?.judicial_officer,
         orders: courtAppearance?.orders,
-        other_notes: courtAppearance?.otherNotes
+        other_notes: courtAppearance?.other_notes
       })
     }
   }, [isOpen])

--- a/client/src/components/molecules/CourtAppearanceAccordion/index.tsx
+++ b/client/src/components/molecules/CourtAppearanceAccordion/index.tsx
@@ -23,7 +23,7 @@ const CourtAppearanceAccordion: FC<Props> = ({ courtAppearance }) => {
           setShow={setShow}
         />
         {show?.show === true && show?.id === courtAppearance?.id && (
-          <AccordionBody orders={courtAppearance?.orders} notes={courtAppearance?.otherNotes} />
+          <AccordionBody orders={courtAppearance?.orders} notes={courtAppearance?.other_notes} />
         )}
       </div>
       <EditCourtAppearanceModal
@@ -67,11 +67,11 @@ const AccordionHeader = ({
         </div>
         <div className="flex flex-col space-y-1">
           <div className="text-slate-500 text-sm font-medium">Judicial Officer</div>
-          <div className=" text-barclerk-10 text-sm">{courtAppearance?.judicialOfficer}</div>
+          <div className=" text-barclerk-10 text-sm">{courtAppearance?.judicial_officer}</div>
         </div>
         <div className="flex flex-col space-y-1">
           <div className="text-sm font-semibold">Next Court Date</div>
-          <div className="font-extrabold text-barclerk-30 text-sm">{moment(courtAppearance?.nextCourtDate).format("D MMMM YYYY")}</div>
+          <div className="font-extrabold text-barclerk-30 text-sm">{moment(courtAppearance?.next_court_date).format("D MMMM YYYY")}</div>
         </div>
       </div>
       <div className="flex items-center pl-4">

--- a/client/src/pages/matter/[id]/client-profile.tsx
+++ b/client/src/pages/matter/[id]/client-profile.tsx
@@ -1,98 +1,103 @@
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode, useEffect, useState } from 'react'
 import { NextPage } from 'next'
+import { useRouter } from 'next/router'
 
 import MatterLayout from '~/components/templates/MatterLayout'
 import ClientProfileCard from '~/components/molecules/ClientProfileCard'
 import Breedcrumb from '~/components/atoms/Breedcrumb'
 import { ChevronDown, FilePlus } from 'react-feather'
+import {
+  reset,
+  fetchClientProfile,
+  fetchSingleClientExtension,
+  fetchAllClientExtensions
+} from '~/redux/client-profile/clientProfileSlice'
+import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
+import { IClientExtension } from '~/shared/interfaces'
+import { CardSkeleton } from '~/components/molecules/ClientProfileCard/CardSkeleton'
+
+interface IExtensionPayload {
+  clientId: number
+  grantId: number
+}
+
+interface IClientProfilePayload {
+  clientId: number
+}
 
 const ClientProfile: NextPage = (): JSX.Element => {
-  // sampleClient JSON file
-  const sampleClient = {
-    id: 1,
-    clientName: 'Damion Carlos Dixon',
-    location: 'Hakea Prison Locked Bag 111 Canning Vale DC WA 6970',
-    contribution: false,
-    onBail: true,
-    court: 'District Court',
-    totalFundUpTo: 30.0,
-    totalFundUsed: 13.4,
-    remainingFund: 16.6,
-    nextCourtDate: '26 October 2022',
-    
-    lastCourtDates: [
-      {
-        id: 1,
-        date: '25 October 2022',
-        orders: 'Lorem ipsum dolor sit amet consectetur adipisicing elit.'
-      },
-      {
-        id: 2,
-        date: '25 October 2022',
-        orders:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus possimus sed, est nam corrupti quaerat molestiae? Deleniti quae, doloribus fugit fuga animi voluptatibus nobis aliquid.Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita at id reprehenderit beatae animi unde inventore itaque eveniet odio architecto quidem eum excepturi, assumenda dolore.'
-      },
-      {
-        id: 3,
-        date: '25 October 2022',
-        orders:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus possimus sed, est nam corrupti quaerat molestiae? Deleniti quae, doloribus fugit fuga animi voluptatibus nobis aliquid.Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita at id reprehenderit beatae animi unde inventore itaque eveniet odio architecto quidem eum excepturi, assumenda dolore.'
-      }
-    ],
-    charges: [
-      {
-        id: 1,
-        name: 'False Name/Details'
-      },
-      {
-        id: 2,
-        name: 'Perjury'
-      },
-      {
-        id: 3,
-        name: 'Possesion Of Drugs With Intent To Sell/Supply Non Trafficable Quantities'
-      },
-      {
-        id: 4,
-        name: 'Selling Drugs Non Trafficable Quantities'
-      },
-      {
-        id: 5,
-        name: 'Selling Drugs Non Trafficable Quantities'
-      },
-      {
-        id: 6,
-        name: 'Selling Drugs Trafficable Quantities'
-      },
-      {
-        id: 7,
-        name: 'Unlawful Possession'
-      }
-    ]
+  const { query } = useRouter()
+  const [selectedGrantId, setSelectedGrantId] = useState<number | null>(null)
+  const dispatch = useAppDispatch()
+
+  const { allClientExtensions, isLoading } = useAppSelector((state) => state.clientProfile) || {}
+
+  const getClientProfileData = async (payload: IClientProfilePayload) => {
+    await dispatch(fetchClientProfile(payload))
+    await dispatch(fetchAllClientExtensions(payload))
   }
+
+  const getSingleClientExtension = async (payload: IExtensionPayload) => {
+    await dispatch(fetchSingleClientExtension(payload))
+  }
+
+  useEffect(() => {
+    getClientProfileData({ clientId: Number(query.id) })
+  }, [query.id])
+
+  useEffect(() => {
+    selectedGrantId &&
+      getSingleClientExtension({ clientId: Number(query.id), grantId: selectedGrantId })
+  }, [selectedGrantId])
+
+  useEffect(() => {
+    if (allClientExtensions && allClientExtensions?.length > 0) {
+      setSelectedGrantId(allClientExtensions[0].id)
+    } else {
+      dispatch(reset())
+    }
+  }, [allClientExtensions])
 
   return (
     <MatterLayout metaTitle="Grant Of Aid">
       <ClientProfileLayout>
-        <Breedcrumb route="Client Profile" />
-        <ClientProfileHeader />
-        <ClientProfileCard clientProfile={sampleClient} />
+        {isLoading ? (
+          <CardSkeleton />
+        ) : (
+          <>
+            <Breedcrumb route="Client Profile" />
+            <ClientProfileHeader
+              allClientExtensions={allClientExtensions}
+              selectedGrantId={selectedGrantId}
+              setSelectedGrantId={setSelectedGrantId}
+            />
+            <ClientProfileCard />
+          </>
+        )}
       </ClientProfileLayout>
     </MatterLayout>
   )
 }
+
 const ClientProfileLayout = ({ children }: { children: ReactNode }): JSX.Element => (
   <section className="mx-auto h-full w-full p-4 md:px-12">{children}</section>
 )
 
-const ClientProfileHeader = (): JSX.Element => {
-  const [showDropdown, setShowDropdown] = useState<boolean>(false);
+const ClientProfileHeader = ({
+  allClientExtensions,
+  selectedGrantId,
+  setSelectedGrantId
+}: {
+  allClientExtensions: IClientExtension[] | null
+  selectedGrantId: number | null
+  setSelectedGrantId: (id: number) => void
+}): JSX.Element => {
+  const [showDropdown, setShowDropdown] = useState<boolean>(false)
 
-  const sampleExtension =  [
-    {id: 1, extension: '22W005912/1'},
-    {id: 2, extension: '22W005912/1'},
-    {id: 3, extension: '22W005912/1'},
-  ];
+  const handleClick = (extension_id: number) => {
+    setSelectedGrantId(extension_id)
+    setShowDropdown(false)
+  }
 
   return (
     <div className="flex items-center justify-between py-4 md:py-6">
@@ -114,17 +119,28 @@ const ClientProfileHeader = (): JSX.Element => {
           onClick={() => setShowDropdown(!showDropdown)}
           className="flex items-center justify-center space-x-1 rounded-r bg-barclerk-60 px-3 py-1.5"
         >
-          <span className="text-barclerk-10">22W005912/1</span>{' '}
+          <span className="text-barclerk-10">
+            {allClientExtensions && allClientExtensions?.length > 0
+              ? [
+                  allClientExtensions[0]?.extension,
+                  selectedGrantId
+                    ? allClientExtensions?.find((x: { id: number }) => x.id === selectedGrantId)?.id
+                    : allClientExtensions[0]?.id
+                ].join('/')
+              : 'No data available.'}
+          </span>{' '}
           <ChevronDown className="text-slate-600" />
         </div>
 
         {showDropdown && (
           <div className="absolute -bottom-1 max-h-32 w-full translate-y-full overflow-y-auto rounded-sm border border-slate-200 bg-barclerk-60 shadow-md">
             <ul>
-              {sampleExtension?.map((extension) => {
+              {allClientExtensions?.map((extension: IClientExtension) => {
                 return (
-                  <div key={extension?.id}>
-                    <li className="p-2 hover:bg-barclerk-30">{extension?.extension}</li>
+                  <div key={extension?.id} onClick={() => handleClick(extension?.id)}>
+                    <li className="p-2 hover:bg-barclerk-30">
+                      {extension?.extension}/{extension?.id}
+                    </li>
                   </div>
                 )
               })}

--- a/client/src/redux/client-profile/clientProfileSlice.ts
+++ b/client/src/redux/client-profile/clientProfileSlice.ts
@@ -1,0 +1,118 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+import { AxiosResponseError } from '~/shared/types'
+import { axios } from '~/shared/lib/axios';
+import '~/shared/interfaces'
+import { IClientExtension, IClientProfile, ISingleClientExtension } from '~/shared/interfaces';
+
+type InitialState = {
+  clientProfile: IClientProfile | null
+  singleClientExtension: ISingleClientExtension | null
+  allClientExtensions: IClientExtension[] | null
+  isError: boolean
+  isSuccess: boolean
+  isLoading: boolean
+  isFundsLoading: boolean
+  error: AxiosResponseError
+}
+
+const initialState: InitialState = {
+  clientProfile: null,
+  singleClientExtension: null,
+  allClientExtensions: null,
+  isError: false,
+  isSuccess: false,
+  isLoading: false,
+  isFundsLoading: false,
+  error: {
+    status: 0,
+    content: null
+  }
+}
+
+export const fetchClientProfile = createAsyncThunk(
+  'dashboard/fetchByClientId',
+  async (payload: {clientId: number}) => {
+    const response = await axios.get(`/dashboard/${payload.clientId}`,)
+    return response.data
+  }
+)
+
+export const fetchAllClientExtensions = createAsyncThunk(
+  'dashboard/fetcAllClientExtensionsByClientId',
+  async (payload: { clientId: number }) => {
+    const response = await axios.get(`/extension/${payload.clientId}`)
+    return response.data
+  }
+)
+
+export const fetchSingleClientExtension = createAsyncThunk(
+  'dashboard/fetchSingleClientExtensionByClientId',
+  async (payload: { clientId: number; grantId: number }) => {
+    const response = await axios.get(`/dashboard/${payload.clientId}/extension/${payload.grantId}`)
+    return response.data
+  }
+)
+
+export const clientProfile = createSlice({
+  name: 'client-profile',
+  initialState,
+  reducers: {
+    reset: (state) => {
+        (state.singleClientExtension = null),
+        (state.isLoading = false),
+        (state.isSuccess = false),
+        (state.isError = false),
+        (state.error = {
+          status: 0,
+          content: null
+        })
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      //  clientProfile
+      .addCase(fetchClientProfile.pending, (state, action) => {
+        state.isLoading = true
+      })
+      .addCase(fetchClientProfile.fulfilled, (state, action) => {
+        state.clientProfile = action.payload
+        state.isLoading = false
+      })
+      .addCase(fetchClientProfile.rejected, (state, action: PayloadAction<any>) => {
+        state.clientProfile = null
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+      // AllExtensions
+      .addCase(fetchAllClientExtensions.pending, (state, action) => {
+        state.isLoading = true
+      })
+      .addCase(fetchAllClientExtensions.fulfilled, (state, action) => {
+        state.allClientExtensions = action.payload
+        state.isLoading = false
+      })
+      .addCase(fetchAllClientExtensions.rejected, (state, action: PayloadAction<any>) => {
+        state.allClientExtensions = null
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+      // SingleExtension
+      .addCase(fetchSingleClientExtension.pending, (state, action) => {
+        state.isFundsLoading = true
+        state.singleClientExtension = null
+      })
+      .addCase(fetchSingleClientExtension.fulfilled, (state, action) => {
+        state.singleClientExtension = action.payload
+        state.isFundsLoading = false
+      })
+  }
+})
+
+export const { reset } = clientProfile.actions
+export default clientProfile.reducer

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -3,13 +3,15 @@ import { createWrapper } from 'next-redux-wrapper'
 
 import authReducer from '~/redux/auth/authSlice'
 import matterReducer from '~/redux/matter/matterSlice' 
+import clientProfileSlice from './client-profile/clientProfileSlice';
 import timeEntrySlice from './time-entry/timeEntrySlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     matter: matterReducer,
-    timeEntry: timeEntrySlice
+    timeEntry: timeEntrySlice,
+    clientProfile: clientProfileSlice,
   }
 })
 

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -21,30 +21,48 @@ export interface IMatter {
   status?: IStatus
 }
 
+export interface IMatterStatus {
+  id: number
+  name: string
+}
+
 export interface IClientProfile {
   id: number
-  clientName: string
-  location?: string
+  client_name: string
   charges?: ICharges[]
-  contribution?: boolean
-  onBail?: boolean
+  contribution?: number
   court?: string
-  totalFundUpTo?: number
-  totalFundUsed?: number
-  remainingFund?: number
-  nextCourtDate?: string
-  lastCourtDates?: ILastCourtDates[]
+  court_appearances?: ICourtAppearance[]
+  extensions?: IExtension[]
+  matter_name?: string
+  matter_status?: IMatterStatus
+  pre_trial_restriction?: IPreTrialRestriction
+  pre_trial_restriction_location_or_address: IPreTrialRestrictionLocation
+}
+
+export interface IPreTrialRestrictionLocation {
+    client_id?: number
+    created_at?: string
+    pre_trial_restriction_id?: number
+    updated_at?: string
+    value?: string
+}
+
+export interface IExtension {
+  id: number
+  extension: string
+  date_effective: number
 }
 
 export interface ICourtAppearance {
   id: number
-  date?: string
-  time?: string
   court?: string
-  judicialOfficer?: string
-  nextCourtDate?: string
+  date?: string
+  judicial_officer?: string
+  next_court_date?: string
   orders?: string
-  otherNotes?: string
+  other_notes?: string
+  time?: string
 }
 
 export interface ILastCourtDates {
@@ -52,6 +70,30 @@ export interface ILastCourtDates {
   date: string
   orders: string
 }
+
+export interface ITypes {
+  id: number
+  type: string
+  rate: number
+  time: number
+  total_allowance: number
+}
+
+export interface IClientExtension {
+  id: number
+  extension?: string
+  types?: ITypes[]
+}
+
+export interface ISingleClientExtension {
+  preparation: number
+  other_types: number
+  attendance: number
+  total_fund: number
+  total_fund_used: number
+  remaining_fund: number
+}
+
 
 export interface IUser {
   id: number


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203234368773394/1203256371568948

## Definition of Done
- [ ] integrate client data in Client Profile page. Includes the ff:
  - [ ] client profile information - contribution, bail status, court, location, list of charges
  - [ ] client court appearances
  - [ ] client extensions
  - [ ] client funds information

## Pre-condition
- [ ] create sample client
- [ ] create GOL data and courtAppearances data for client

## Expected Output
  - [ ] when the user opens a client record from Dashboard Page, they will be redirected to the client's profile.
  - [ ] if client has extensions available, when user clicks on the client_extension dropdown, it will show the list of available extensions. Otherwise, if the client has no client_extension, 'no available data' message is shown on the dropdown. The client's funds are shown based on active client_extension from the dropdown. 
  - [ ] the client's court_appearances data are shown on the right portion of the page. If there are no court_appearances available for the client, 'no data available' message is shown instead.

## Screenshots/Recordings
[Main Dashboard _ Barclerk.webm](https://user-images.githubusercontent.com/118783823/206465681-0b77d107-6e4f-4b9c-935d-6008e769fde4.webm)