### PR TITLE
[BarClerk-991] - [Bugtask] Set limit to three Court Appearance items …

### DIFF
--- a/client/src/components/molecules/ClientProfileCard/index.tsx
+++ b/client/src/components/molecules/ClientProfileCard/index.tsx
@@ -158,7 +158,7 @@ const ClientProfileCard: FC = (): JSX.Element => {
           </div>
           <ul className="py-2 px-6 text-slate-600">
             {clientProfile?.court_appearances && clientProfile?.court_appearances?.length > 0 ? (
-              clientProfile?.court_appearances?.map((lastcourtdate) => {
+              clientProfile?.court_appearances?.slice(0, 3).map((lastcourtdate) => {
                 return (
                   <li key={lastcourtdate?.id} className="border-b border-slate-500 px-2 py-6">
                     <div className="flex">


### PR DESCRIPTION
…in Client Page

## Issue Link
- https://app.asana.com/0/1203234368773394/1203484637241529

## Definition of Done
- [ ] Limit the CourtAppearances list in ClientProfile Page to just  three (3) latest records

## Pre-condition
- [ ] There should be more than three CourtAppearances for the client to test out the update 
- [ ] Creating more than three CourtAppearances will only present the three latest records. Clicking the `view more` button will redirect the user to the CourtAppearancesPage where all the records can be viewed.

## Screenshots/Recordings
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/118783823/206907526-cc3644f5-ec56-4f03-bbfa-a904593d3aa6.png">
