### PR TITLE
[270] - [BugTask] Add Sum of Preparation for a Specific Extension in the Client Dashboard

### DIFF
--- a/api/app/Models/Client.php
+++ b/api/app/Models/Client.php
@@ -194,10 +194,10 @@ class Client extends Model
     {
         $totalFund = $this->totalFund($grant);
         $remainingFund = $totalFund - $this->totalAmountOfTimeEntries($grant);
-        $totalFundUsed = (($totalFund - ($remainingFund)) / $totalFund);
+        $totalFundUsed = (($totalFund - ($remainingFund)) / $totalFund) * 100;
 
         return [
-            'preparation' => $grant->timeEntries()->preparation()->firstOr('amount', fn () => 0),
+            'preparation' => round($grant->timeEntries()->preparation()->sum('amount'), 2),
             'other_types' => round($grant->timeEntries()->otherTypes()->sum('amount'), 2),
             'attendance' => round($grant->timeEntries()->attendance()->sum('amount'), 2),
             'total_fund' => $totalFund,

--- a/api/database/json/types.json
+++ b/api/database/json/types.json
@@ -933,14 +933,14 @@
     {
         "code": "C31",
         "type": "Disbursements (mileage)",
-        "rate": 88,
+        "rate": 133,
         "time": 3,
         "total_allowance": 264
     },
     {
         "code": "C31",
         "type": "Travel Time",
-        "rate": 133,
+        "rate": 88,
         "time": 1,
         "total_allowance": 133
     },

--- a/client/src/components/molecules/ClientProfileCard/index.tsx
+++ b/client/src/components/molecules/ClientProfileCard/index.tsx
@@ -110,7 +110,7 @@ const ClientProfileCard: FC = (): JSX.Element => {
                 <LineSkeleton className="h-5 w-3/4" />
               ) : (
                 <div className="flex justify-end lg:justify-center">
-                  ${singleClientExtension?.preparation?.amount || 0}
+                  ${singleClientExtension?.preparation || 0}
                 </div>
               )}
             </div>

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -86,9 +86,7 @@ export interface IClientExtension {
 }
 
 export interface ISingleClientExtension {
-  preparation: {
-    amount: number
-  }
+  preparation: number
   other_types: number
   attendance: number
   total_fund: number


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203234368773394/1203530870578270/f

## Definition of Done
- [x] Get the sum of the total preparations for that specific extension

## Notes
- Multiplied Total Funds used by 100
- Updated seeder for types.json

## Pre-condition
- php artisan db:seed
- Go add more time entries typed preparation

## Expected Output
- In the client dashboard it will display the sum of all the preparations for the extension in the Preparation Section

## Screenshots/Recordings
[preparation-fix.webm](https://user-images.githubusercontent.com/108660012/206979112-309203f3-a2bc-49e8-b990-66f7e7d6aaa7.webm)

